### PR TITLE
Default to int on custom format types

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -495,10 +495,8 @@ func oapiSchemaToGoType(schema *openapi3.Schema, path []string, outSchema *Schem
 			outSchema.GoType = "uint8"
 		} else if f == "uint" {
 			outSchema.GoType = "uint"
-		} else if f == "" {
-			outSchema.GoType = "int"
 		} else {
-			return fmt.Errorf("invalid integer format: %s", f)
+			outSchema.GoType = "int"
 		}
 		outSchema.DefineViaAlias = true
 	case "number":


### PR DESCRIPTION
The OpenAPI Spec [states](https://swagger.io/docs/specification/data-models/keywords/) the following for `format`:
> OpenAPI has its own predefined formats and also allows custom formats

Therefore the code generation should not throw an error when it encounters unexpected integer formats, and should instead default to `int`.

I ran into this while attempting to parse the Bungie API Spec which included a `format` value of `byte`. See https://github.com/Bungie-net/api/issues/1452